### PR TITLE
Add .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+
+Zeplin_Raid/


### PR DESCRIPTION
This pull request adds in a .gitignore file that tells git to ignore any files that should not be pushed to the repository. Right now it just blocks __pycache__ files but can easily be updated to include more files.